### PR TITLE
block device name match: add nvme (and mmc) support 

### DIFF
--- a/rename-efi-entry.bash
+++ b/rename-efi-entry.bash
@@ -145,9 +145,9 @@ if [ -z "$device_for_uuid" ] ; then
 fi
 
 # verify that device name matches expected pattern
-if [[ $device_for_uuid =~ ^(/dev/[a-z]{3})([[:digit:]]+) ]] ; then
+if [[ $device_for_uuid =~ ^(/dev/(sd[a-z]|nvme[[:digit:]]+n[[:digit:]]+|mmcblk[[:digit:]]+))p?([[:digit:]]+)$ ]] ; then
   device_name=${BASH_REMATCH[1]}
-  device_part=${BASH_REMATCH[2]}
+  device_part=${BASH_REMATCH[3]}
 else
   echo "$0 : ERROR : unexpected device name format '$device_for_uuid' found by 'sfdisk' for partition that relates to the given label."
   exit 1


### PR DESCRIPTION
I have an NVMe drive, and NVMe block devices use a different naming format ([see related Arch doc for more info](https://wiki.archlinux.org/index.php/Device_file#NVMe)). With this, NVMe-based boot drives are now supported.

I tried to include SCSI- and MMC-based formats, and while they work with the regex match, I did not run them on a real setup (I can only vouch for NVMe-based match on real hardware).

Please let me know if any improvements can be included, thanks!