### PR TITLE
Fix efibootmgr inconsistency

### DIFF
--- a/rename-efi-entry.bash
+++ b/rename-efi-entry.bash
@@ -43,6 +43,30 @@ print_usage_and_efi_data () {
   efibootmgr --verbose
 }
 
+# function to print debug messages if test_mode is enabled
+# usage: debug "your message here"
+debug() {
+  if [[ $test_mode -eq 1 ]]; then
+    echo "DEBUG: $*" >&2
+  fi
+}
+
+# The reason we are doing is because it seems that efibootmgr output differ slightly across different distros.
+# Arch and Fedora do not have the `File` prefix in the loader path, while Ubuntu and Mint does.
+
+# standard efibootmgr (most common): ends with loader path
+REGEX_LOADER='^Boot([[:xdigit:]]{4})\*?[[:blank:]]+(.+)[[:blank:]]+HD\(([[:digit:]]+),[^,]+,([^,]+)[^\)]+\)\/(.+)$'
+
+# alternative format: loader path wrapped in File(...)
+REGEX_LOADER_FILE='^Boot([[:xdigit:]]{4})\*?[[:blank:]]+(.+)[[:blank:]]+HD\(([[:digit:]]+),[^,]+,([^,]+)[^\)]+\)\/File\(([^\)]+)\)$'
+
+# sfdisk format for extracting device and partition uuid
+# e.g. /dev/sda1 : start=..., size=..., ..., uuid=2FFCC127-F6CE-40F0-9932-D1DFD14E9462
+REGEX_SFDISK_UUID='^([^[:blank:]]+)[[:blank:]]:[[:blank:]].*[[:blank:]]uuid=([^,]+)'
+
+REGEX_UUID='^(/dev/(sd[a-z]|nvme[[:digit:]]+n[[:digit:]]+|mmcblk[[:digit:]]+))p?([[:digit:]]+)$'
+# ----------------------------------------------------------------------------------------------------------------------
+
 # script start ---------------------------------------------------------------------------------------------------------
 
 # check whether we run as root
@@ -68,12 +92,28 @@ old_label="$1"
 new_label="$2"
 old_bootnum="$3"
 
+# default: execute normally
+test_mode=0
+
+# parse remaining arguments for optional flags
+for arg in "$@"; do
+  if [[ "$arg" == "--test" ]]; then
+    test_mode=1
+  fi
+done
+
+if [[ $test_mode -eq 1 ]]; then
+  echo "$0 : INFO : test mode enabled; no commands will be executed, only verification and dry run"
+fi
+
+
 # obtain disk device names as `disk_names` array -----------------------------------------------------------------------
 
 # obtain disk data as long text
 disk_data_all=$(lsblk --nodeps --noheadings --pairs | grep 'TYPE="disk"')
 
 # split disk data into a string array
+debug "Finding disk devices..."
 readarray -t disk_data_array <<<"$disk_data_all"
 
 # obtain an array of disk names
@@ -81,11 +121,13 @@ disk_names=()
 for disk_data_line in "${disk_data_array[@]}" ; do
   if [[ $disk_data_line =~ ^NAME=\"([^\"]+)\" ]] ; then
     disk_names+=(${BASH_REMATCH[1]})
+    debug "Found disk: ${BASH_REMATCH[1]}"
   fi
 done
 # ----------------------------------------------------------------------------------------------------------------------
 
 # obtain an associative array of devices against partition uuid values -------------------------------------------------
+debug "Mapping partition UUIDs to device names..."
 
 # the associative array to be filled
 # data example : partitions['2ffcc127-f6ce-40f0-9932-d1dfd14e9462']='/dev/sda1'
@@ -93,6 +135,7 @@ declare -A partitions
 
 # loop over all disk devices
 for disk_name in "${disk_names[@]}" ; do
+  debug "Scanning disk /dev/$disk_name for partitions..."
   # obtain partition data as long text, suppressing possible error messages in stderr,
   #   e.g. "sfdisk: /dev/sdb: does not contain a recognized partition table"
   # NOTE sfdisk call requires `sudo`
@@ -107,16 +150,22 @@ for disk_name in "${disk_names[@]}" ; do
   #   /dev/sda1 : start=        2048, size=     1048576, type=C12A7328-F81F-11D2-BA4B-00A0C93EC93B, uuid=2FFCC127-F6CE-40F0-9932-D1DFD14E9462, name="EFI System Partition"
   #   /dev/sda1 : start=        2048, size=     1048576, type=C12A7328-F81F-11D2-BA4B-00A0C93EC93B, uuid=2FFCC127-F6CE-40F0-9932-D1DFD14E9462
   for partition_data_line in "${partition_data_array[@]}" ; do
-    if [[ $partition_data_line =~ ^([^[:blank:]]+)[[:blank:]]:[[:blank:]].*[[:blank:]]uuid=([^,]+) ]] ; then
+    if [[ $partition_data_line =~ $REGEX_SFDISK_UUID ]] ; then
       device=${BASH_REMATCH[1]}
       uuid_lowercase="${BASH_REMATCH[2],,}"
       partitions[$uuid_lowercase]=$device
+      debug "Mapped UUID $uuid_lowercase to $device"
+
     fi
   done
 done
+if [ ${#partitions[@]} -eq 0 ]; then
+    echo "$0 : WARNING : Could not find any partitions with UUIDs via sfdisk."
+fi
 # ----------------------------------------------------------------------------------------------------------------------
 
 # obtain EFI data ------------------------------------------------------------------------------------------------------
+debug "Scanning EFI boot entries..."
 
 # obtain EFI data as long text
 efi_data_all=$(efibootmgr --verbose)
@@ -153,6 +202,7 @@ if [ -z "$target_bootnum" ] ; then
   echo "$0 : ERROR : no EFI data found for any label matching '$old_label'."
   exit 1
 fi
+debug "Target found: BootNum=$target_bootnum, Part=$target_part, UUID=$target_uuid, Loader=$target_loader"
 
 # obtain device for the partition with uuid that corresponds to the given label
 device_for_uuid=${partitions[$target_uuid]}
@@ -160,6 +210,7 @@ if [ -z "$device_for_uuid" ] ; then
   echo "$0 : ERROR : EFI label '$old_label' is related to partition '$target_uuid' that is not currently known to the system."
   exit 1
 fi
+debug "Partition UUID $target_uuid corresponds to device $device_for_uuid"
 
 # verify that device/partition name matches some expected pattern;
 # the following partition name patterns/samples are recognized:
@@ -167,7 +218,7 @@ fi
 # - NVMe        : e.g. /dev/nvme0n1p1
 # - MMC family  : e.g. /dev/mmcblk0p1
 # see https://wiki.archlinux.org/index.php/Device_file#Block_device_names
-if [[ $device_for_uuid =~ ^(/dev/(sd[a-z]|nvme[[:digit:]]+n[[:digit:]]+|mmcblk[[:digit:]]+))p?([[:digit:]]+)$ ]] ; then
+if [[ $device_for_uuid =~ $REGEX_UUID ]] ; then
   device_name=${BASH_REMATCH[1]}
   device_part=${BASH_REMATCH[3]}
 else
@@ -176,13 +227,13 @@ else
 fi
 
 # verify that partition number of the device matches partition number in the EFI entry
-if [[ $device_part != $target_part ]] ; then
+if [[ $device_part != "$target_part" ]] ; then
   echo "$0 : ERROR : partition number of the device [$device_part] is different from partition number in the EFI entry [$target_part]."
   exit 1
 fi
 
 # prepare efibootmgr commands to be executed
-printf -v escaped_loader "%q" $target_loader
+printf -v escaped_loader "%q" "$target_loader"
 efi_command_1="efibootmgr --bootnum $target_bootnum --delete-bootnum"
 efi_command_2="efibootmgr --create --disk $device_name --part $target_part --label '$new_label' --loader $escaped_loader"
 


### PR DESCRIPTION
- extra branch in the main if-else block that addresses the alternate output of `efibootmgr`
- Added an optional `--test` mode